### PR TITLE
Scripted test for sbt-metals

### DIFF
--- a/src/sbt-test/load-plugin/metals/build.sbt
+++ b/src/sbt-test/load-plugin/metals/build.sbt
@@ -1,0 +1,4 @@
+commands += Command.command("do-apply") { state =>
+  val cp = sys.props("load.plugin.path")
+  s"apply -cp $cp ch.epfl.scala.loadplugin.LoadPlugin" :: state
+}

--- a/src/sbt-test/load-plugin/metals/src/main/scala/A.scala
+++ b/src/sbt-test/load-plugin/metals/src/main/scala/A.scala
@@ -1,0 +1,1 @@
+object Foobar

--- a/src/sbt-test/load-plugin/metals/test
+++ b/src/sbt-test/load-plugin/metals/test
@@ -1,0 +1,13 @@
+> do-apply
+
+> load-plugin org.scalameta:sbt-metals:0.1.0-M1 scala.meta.sbt.MetalsPlugin
+> semanticdbEnable
+> compile
+$ exists target/scala-2.12/classes/META-INF/semanticdb/src/main/scala/A.semanticdb
+
+> load-plugin org.scalameta:sbt-metals:0.1.0-M1 scala.meta.sbt.MetalsPlugin
+$ absent .metals/buildinfo/
+> Compile/metalsWriteBuildInfo
+$ exists .metals/buildinfo/metals/compile.properties
+> Test/metalsWriteBuildInfo
+$ exists .metals/buildinfo/metals/test.properties


### PR DESCRIPTION
Hi @Duhemm! 👋 It's a very interesting project! 

I wanted to try it with the [Metals sbt plugin](https://github.com/scalameta/metals/blob/master/sbt-metals/src/main/scala/scala/meta/sbt/MetalsPlugin.scala) we got recently and added some scripted test for it. There is some strange stuff happening: 

* I couldn't run `metalsSetup` command which is just an alias for calling `semanticdbEnable` and then `*/metalsWriteBuildInfo`. To call each of these commands I had to call `load-plugin` again.
* I also tried calling `metalsWriteBuildInfo`, which is an aggregating task for `Compile/metalsWriteBuildInfo` + `Test/metalsWriteBuildInfo` and I see output
    ```
    Wrote /private/var/.../metals/.metals/buildinfo/metals/compile.properties
    ...
    Wrote /private/var/.../metals/.metals/buildinfo/metals/test.properties
    ```
   But then `.../compile.properties` doesn't exist (gets wiped between the task calls?) and the check fails.
   So I called these two tasks separately.

Do you know why it's happening? I can add failing cases if it helps.