### PR TITLE
Add `if-absent` command

### DIFF
--- a/notes/0.2.0.markdown
+++ b/notes/0.2.0.markdown
@@ -1,0 +1,4 @@
+- Add `if-absent` command. This command tests whether a plugin has been loaded
+  as part of the build (i.e. it **won't see** plugins loaded with
+  `load-plugin`), and executes one or more commands if the plugin is absent.
+  

--- a/src/sbt-test/if-absent/basic/build.sbt
+++ b/src/sbt-test/if-absent/basic/build.sbt
@@ -1,0 +1,4 @@
+commands += Command.command("do-apply") { state =>
+  val cp = sys.props("load.plugin.path")
+  s"apply -cp $cp ch.epfl.scala.loadplugin.LoadPlugin" :: state
+}

--- a/src/sbt-test/if-absent/basic/project/plugins.sbt
+++ b/src/sbt-test/if-absent/basic/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/sbt-test/if-absent/basic/test
+++ b/src/sbt-test/if-absent/basic/test
@@ -1,0 +1,3 @@
+> do-apply
+> if-absent sbtassembly.AssemblyPlugin fail
+> assembly

--- a/src/sbt-test/if-absent/if-absent-load-assembly/build.sbt
+++ b/src/sbt-test/if-absent/if-absent-load-assembly/build.sbt
@@ -1,0 +1,4 @@
+commands += Command.command("do-apply") { state =>
+  val cp = sys.props("load.plugin.path")
+  s"apply -cp $cp ch.epfl.scala.loadplugin.LoadPlugin" :: state
+}

--- a/src/sbt-test/if-absent/if-absent-load-assembly/test
+++ b/src/sbt-test/if-absent/if-absent-load-assembly/test
@@ -1,0 +1,5 @@
+> do-apply
+-> assembly
+> if-absent sbtassembly.AssemblyPlugin "load-plugin com.eed3si9n:sbt-assembly:0.14.6 sbtassembly.AssemblyPlugin"
+> assembly
+


### PR DESCRIPTION
This command tests whether a plugin has been loaded in the build and
executes one or more actions if the plugin is absent.